### PR TITLE
Bump standard-jsx version

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "babel-eslint": "^7.2.3",
     "eslint": "^4.0.0",
-    "eslint-config-standard-jsx": "^4.0.2",
+    "eslint-config-standard-jsx": "^6.0.2",
     "eslint-plugin-react": "^7.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Fixes this error:

> (node:10982) [ESLINT_LEGACY_OBJECT_REST_SPREAD] DeprecationWarning: The 'parserOptions.ecmaFeatures.experimentalObjectRestSpread' option is deprecated. Use 'parserOptions.ecmaVersion' instead. (found in "../node_modules/eslint-config-standard-jsx/index.js")

Greenkeeper was right in #7 :)